### PR TITLE
chore(dépendances): clean up dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
   - 0.10
-before_install:
-  - npm install -g bower@~1.3.10
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # angular-draganddrop
-[![Build Status](https://travis-ci.org/neoziro/angular-draganddrop.svg?branch=master)](https://travis-ci.org/neoziro/angular-draganddrop)
+[![Build Status](https://travis-ci.org/lemonde/angular-draganddrop.svg?branch=master)](https://travis-ci.org/lemonde/angular-draganddrop)
 [![Dependency Status](https://david-dm.org/neoziro/angular-draganddrop.svg?theme=shields.io)](https://david-dm.org/neoziro/angular-draganddrop)
 [![devDependency Status](https://david-dm.org/neoziro/angular-draganddrop/dev-status.svg?theme=shields.io)](https://david-dm.org/neoziro/angular-draganddrop#info=devDependencies)
 

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "angular": ">=1.2.0"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.6",
+    "angular-mocks": "~1.3.9",
     "jquery": "~2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "https://github.com/neoziro/angular-draganddrop/issues"
   },
   "devDependencies": {
+    "bower": "~1.3.3",
     "chai": "^1.9.1",
     "chai-jquery": "^1.2.1",
     "grunt": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -24,16 +24,16 @@
   },
   "devDependencies": {
     "bower": "~1.3.3",
-    "chai": "^1.9.1",
-    "chai-jquery": "^1.2.1",
-    "grunt": "^0.4.4",
-    "grunt-contrib-uglify": "^0.4.0",
-    "karma": "^0.12.14",
-    "karma-chrome-launcher": "^0.1.3",
-    "karma-firefox-launcher": "^0.1.3",
-    "karma-mocha": "^0.1.3",
-    "mocha": "^1.18.2",
-    "sinon": "^1.9.1",
-    "sinon-chai": "^2.5.0"
+    "chai": "~1.9.1",
+    "chai-jquery": "~1.2.3",
+    "grunt": "~0.4.1",
+    "grunt-contrib-uglify": "~0.2.2",
+    "karma": "~0.12.12",
+    "karma-chrome-launcher": "~0.1.3",
+    "karma-firefox-launcher": "~0.1.3",
+    "karma-mocha": "~0.1.3",
+    "mocha": "~1.20.1",
+    "sinon": "~1.10.3",
+    "sinon-chai": "~2.5.0"
   }
 }


### PR DESCRIPTION
A little clean-up in the dependencies of the project:

* add bower as a development dependency (no more `npm install -g`)
* use patch constraint for all dependencies (npm & bower)
* bump some dependencies versions